### PR TITLE
Convert encoding of strings before running through `iconv()`

### DIFF
--- a/src/Fetch/MIME.php
+++ b/src/Fetch/MIME.php
@@ -36,8 +36,14 @@ final class MIME
 
         foreach (imap_mime_header_decode($text) as $word) {
             $ch = 'default' === $word->charset ? 'ascii' : $word->charset;
+            $text = $word->text;
+            if (function_exists('mb_convert_encoding')) {
+                // This will strip any unrecognised characters and ensure we avoid
+                // "Detected an incomplete multibyte character in input string" errors
+                $text = mb_convert_encoding($text, $targetCharset, mb_detect_encoding($text, mb_detect_order()));
+            }
 
-            $result .= iconv($ch, $targetCharset, $word->text);
+            $result .= iconv($ch, $targetCharset, $text);
         }
 
         return $result;

--- a/src/Fetch/MIME.php
+++ b/src/Fetch/MIME.php
@@ -40,7 +40,7 @@ final class MIME
             if (function_exists('mb_convert_encoding')) {
                 // This will strip any unrecognised characters and ensure we avoid
                 // "Detected an incomplete multibyte character in input string" errors
-                $text = mb_convert_encoding($text, $targetCharset, mb_detect_encoding($text, mb_detect_order()));
+                $text = mb_convert_encoding($text, $ch, $ch);
             }
 
             $result .= iconv($ch, $targetCharset, $text);


### PR DESCRIPTION
We were receiving a lot of errors with mandarin strings, 
This fix will change unknown characters to `?` and prevent `iconv()` throwing an error